### PR TITLE
require the entire s3 prefix from users

### DIFF
--- a/acceptance/lifecycle_test.go
+++ b/acceptance/lifecycle_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Lifecycle test", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					remotePaths[i] = fmt.Sprintf(
-						"product_files/%s/%s",
+						"%s/%s",
 						s3FilepathPrefix,
 						sourceFileNames[i],
 					)

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -202,15 +202,16 @@ var _ = Describe("Filter", func() {
 
 	Describe("Download Links", func() {
 		It("returns the download links", func() {
+			// FIXME this default behaviour will need fixing
 			productFiles := []pivnet.ProductFile{
 				{
 					ID:           3,
-					AWSObjectKey: "product_files/banana/file-name-1.zip",
+					AWSObjectKey: "banana/file-name-1.zip",
 					Links:        &pivnet.Links{Download: map[string]string{"href": "/products/banana/releases/666/product_files/6/download"}},
 				},
 				{
 					ID:           4,
-					AWSObjectKey: "product_files/banana/file-name-2.zip",
+					AWSObjectKey: "banana/file-name-2.zip",
 					Links:        &pivnet.Links{Download: map[string]string{"href": "/products/banana/releases/666/product_files/8/download"}},
 				},
 			}

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -40,7 +40,7 @@ func (c Client) UploadFile(exactGlob string) (string, error) {
 
 	filename := filepath.Base(exactGlob)
 
-	remoteDir := "product_files/" + c.filepathPrefix + "/"
+	remoteDir := c.filepathPrefix + "/"
 	remotePath := fmt.Sprintf("%s%s", remoteDir, filename)
 
 	err := c.transport.Upload(

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Uploader", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(remotePath).To(Equal(
-					fmt.Sprintf("product_files/%s/file-0", filepathPrefix)))
+					fmt.Sprintf("%s/file-0", filepathPrefix)))
 			})
 		})
 


### PR DESCRIPTION
This is not a completely tested edit, and you couldn't accept it without breaking existing uses.

PivNet is now using a bastion s3 bucket for uploading the bits, and they internally move them across to the pivnet s3 bucket after the release is created.

The new bucket has the prefix `product-files/your-slug/`

I needed to use this new format, so we provide our s3_filename_prefix to the pivnet-resource as `product-files/application-watchdog-for-pcf` and it works beautifully with this edit.

@crawsible paired with me so can also provide context if you need it. 
