### PR TITLE
Retry downloads that fail on copying from S3

### DIFF
--- a/acceptance/lifecycle_test.go
+++ b/acceptance/lifecycle_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Lifecycle test", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					remotePaths[i] = fmt.Sprintf(
-						"product_files/%s/%s",
+						"%s/%s",
 						s3FilepathPrefix,
 						sourceFileNames[i],
 					)


### PR DESCRIPTION
This PR bumps `github.com/pivotal-cf/go-pivnet` to `v0.0.32 (ed7e2b7f78c9c367eb8bf96c1972466de21f61cb)` and handles the returned `retryable` boolean from `ExtendedClient#DownloadFile`, attempting a maximum of three downloads if failures are retryable.

This is in response to https://github.com/pivotal-cf/pivnet-resource/issues/38.

**NB**: The final commit of this PR changes `acceptance/lifecycle_test.go` to remove the `product_files` prefixing of the `S3_FILEPATH_PREFIX` set for acceptance tests. This may break CI if `product_files` is not automatically prepended to s3 filepath prefixes.
- Have you made this pull request to the `develop` branch?
  Yes.
- Have you [run the tests locally](https://github.com/pivotal-cf/pivnet-resource#running-the-tests)?
  Yes.
