### PR TITLE
Skip SSL Validation supported

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -67,6 +67,7 @@ func main() {
 		Host:      endpoint,
 		Token:     input.Source.APIToken,
 		UserAgent: useragent.UserAgent(version, "check", input.Source.ProductSlug),
+		SkipSSLValidation: input.Source.SkipSSLValidation,
 	}
 	client := gp.NewClient(
 		clientConfig,

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -89,6 +89,7 @@ func main() {
 		Host:      endpoint,
 		Token:     input.Source.APIToken,
 		UserAgent: useragent.UserAgent(version, "get", input.Source.ProductSlug),
+		SkipSSLValidation: input.Source.SkipSSLValidation,
 	}
 
 	client := gp.NewClient(

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -95,6 +95,7 @@ func main() {
 		Host:      endpoint,
 		Token:     input.Source.APIToken,
 		UserAgent: useragent.UserAgent(version, "put", input.Source.ProductSlug),
+		SkipSSLValidation: input.Source.SkipSSLValidation,
 	}
 
 	client := gp.NewClient(
@@ -119,6 +120,7 @@ func main() {
 		Bucket:          bucket,
 		Stderr:          os.Stderr,
 		Logger:          ls,
+		SkipSSLValidation: input.Source.SkipSSLValidation,
 	})
 
 	uploaderClient := uploader.NewClient(uploader.Config{

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -18,6 +18,7 @@ type Source struct {
 	Region          string `json:"region"`
 	ReleaseType     string `json:"release_type"`
 	SortBy          SortBy `json:"sort_by"`
+	SkipSSLValidation bool `json:"skip_ssl_verification"`
 }
 
 type CheckRequest struct {

--- a/s3/s3_client.go
+++ b/s3/s3_client.go
@@ -29,11 +29,12 @@ type NewClientConfig struct {
 
 	Logger logger.Logger
 	Stderr io.Writer
+	SkipSSLValidation bool
 }
 
 func NewClient(config NewClientConfig) *Client {
 	endpoint := ""
-	disableSSL := false
+	disableSSL := config.SkipSSLValidation
 
 	awsConfig := s3resource.NewAwsConfig(
 		config.AccessKeyID,

--- a/vendor/github.com/pivotal-cf/go-pivnet/pivnet.go
+++ b/vendor/github.com/pivotal-cf/go-pivnet/pivnet.go
@@ -71,7 +71,7 @@ func NewClient(
 
 	ranger := download.NewRanger(concurrentDownloads)
 	downloader := download.Client{
-		HTTPClient: http.DefaultClient,
+		HTTPClient: httpClient,
 		Ranger:     ranger,
 		Logger:     logger,
 	}


### PR DESCRIPTION
Enables Skipping SSL Validation for customers with MITM proxies and custom CAs.   

Related fix https://github.com/pivotal-cf/go-pivnet/pull/16