### PR TITLE
Document maximum description length

### DIFF
--- a/metadata/README.md
+++ b/metadata/README.md
@@ -16,7 +16,7 @@ release:
   release_date: 1997-12-31
   eula_slug: "pivotal_beta_eula"
   description: |
-    "wow this is a long description for this product"
+    "wow this is a long description for this product (150 chars max)"
   release_notes_url: http://example.com
   availability: Selected User Groups Only
   product_files:


### PR DESCRIPTION
The maximum length for the description field is 150 chars.

Trying to set anything larger raises:

```
ERROR: 422 - validation errors creating release for product 'p-bosh-backup-and-restore'. Errors: Description is too long (maximum is 150 characters)
```

with @henryaj