### PR TITLE
Allows for passive globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ for more details on the structure of the metadata file.
   - The globs match on the actual *file names*, not the display names in Pivotal
   Network. This is to provide a more consistent experience between uploading and
   downloading files.
-  - If one or more globs fails to match any files the release download fails
+  - If the globs fail to match any files the release download fails
   with error.
+  - If one or more globs fails to match any files, only the matched files will be downloaded.
   - If `globs` is not provided (or is nil), **all files will be downloaded**.
   - If `globs` is not provided (or is nil), and there are no files to download
   - Setting `globs` to the empty array (i.e. `globs: []`) will not attempt to

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -58,8 +58,6 @@ func (f Filter) ProductFileKeysByGlobs(
 
 	filtered := []pivnet.ProductFile{}
 	for _, pattern := range globs {
-		prevFilteredCount := len(filtered)
-
 		for _, p := range productFiles {
 			parts := strings.Split(p.AWSObjectKey, "/")
 			fileName := parts[len(parts)-1]
@@ -74,9 +72,10 @@ func (f Filter) ProductFileKeysByGlobs(
 			}
 		}
 
-		if len(filtered) == prevFilteredCount {
-			return nil, fmt.Errorf("no match for glob: '%s'", pattern)
-		}
+	}
+
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("no match for glob(s): '%s'", strings.Join(globs, ", "))
 	}
 
 	return filtered, nil

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -247,6 +247,23 @@ var _ = Describe("Filter", func() {
 			Expect(filtered).To(Equal([]pivnet.ProductFile{productFiles[1], productFiles[2]}))
 		})
 
+		Describe("When a glob that matches a file and glob that does not match a file", func() {
+			BeforeEach(func() {
+				globs = []string{"file-1", "does-not-exist.txt"}
+			})
+
+			It("returns an error", func() {
+				filtered, err := f.ProductFileKeysByGlobs(
+					productFiles,
+					globs,
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(filtered).To(HaveLen(1))
+				Expect(filtered).To(Equal([]pivnet.ProductFile{productFiles[1]}))
+			})
+		})
+
 		Context("when a bad pattern is passed", func() {
 			BeforeEach(func() {
 				globs = []string{"["}
@@ -273,23 +290,9 @@ var _ = Describe("Filter", func() {
 					globs,
 				)
 				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("no match for glob(s): '*will-not-match*'"))
 
 				Expect(filtered).To(HaveLen(0))
-			})
-		})
-
-		Describe("When a glob that matches a file and glob that does not match a file", func() {
-			BeforeEach(func() {
-				globs = []string{"file-1", "does-not-exist.txt"}
-			})
-
-			It("returns an error", func() {
-				_, err := f.ProductFileKeysByGlobs(
-					productFiles,
-					globs,
-				)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("no match for glob: 'does-not-exist.txt'"))
 			})
 		})
 	})


### PR DESCRIPTION
This will allow Strabo to track down OSL files that currently have many different naming formats on Pivnet.

- Have you made this pull request to the `develop` branch?
No. Was told not to.

- Have you [run the tests locally](https://github.com/pivotal-cf/pivnet-resource#running-the-tests)?
For the suite that was affects, yes. Was told the test suite was already compromised so leaving the team/pipeline to do final validation.
