### PR TITLE
Fix refresh token usage

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	if len(apiToken) > legacyAPITokenLength {
 		usingUAAToken = true
-		tokenFetcher := uaa.NewTokenFetcher(input.Source.Endpoint, apiToken)
+		tokenFetcher := uaa.NewTokenFetcher(endpoint, apiToken)
 		apiToken, err = tokenFetcher.GetToken()
 
 		if err != nil {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	if len(apiToken) > legacyAPITokenLength {
 		usingUAAToken = true
-		tokenFetcher := uaa.NewTokenFetcher(input.Source.Endpoint, apiToken)
+		tokenFetcher := uaa.NewTokenFetcher(endpoint, apiToken)
 		apiToken, err = tokenFetcher.GetToken()
 
 		if err != nil {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	if len(apiToken) > legacyAPITokenLength {
 		usingUAAToken = true
-		tokenFetcher := uaa.NewTokenFetcher(input.Source.Endpoint, apiToken)
+		tokenFetcher := uaa.NewTokenFetcher(endpoint, apiToken)
 		apiToken, err = tokenFetcher.GetToken()
 
 		if err != nil {

--- a/uaa/uaa.go
+++ b/uaa/uaa.go
@@ -35,11 +35,11 @@ func (t TokenFetcher) GetToken() (string, error) {
 	}
 
 	resp, err := httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return "", fmt.Errorf("API token request failed: %s", err.Error())
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("failed to fetch API token - received status %v", resp.StatusCode)


### PR DESCRIPTION
- UAA token fetcher was inadvertently using an empty URL if an endpoint
wasn't set
- Move defer to after error check, since if there's an error here the
defer will blow up with a null pointer panic