### PR TITLE
Change re-upload behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ and added to the file metadata in Pivotal Network.
 
 **If the AWS key matches an existing file, but the SHA does not match, you will now receive an error and need to rename the file.**
 
-**Existing releases with the same version will be deleted and recreated.**
+**Existing releases with the same version will _not_ be deleted and recreated by
+default, and will instead result in an error.**
 
 See [metadata](https://github.com/pivotal-cf/pivnet-resource/blob/master/metadata)
 for more details on the structure of the metadata file.
@@ -197,6 +198,10 @@ release creation will fail.
 
   See [metadata](https://github.com/pivotal-cf/pivnet-resource/blob/master/metadata)
   for more details on the structure of the metadata file.
+
+* `override`: *Optional.*
+  Boolean. Forces re-upload of releases of releases and versions that are
+  already present on the Pivotal Network.
 
 ### Some Common Gotchas
 

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -62,6 +62,7 @@ type OutParams struct {
 	FileGlob       string `json:"file_glob"`
 	FilepathPrefix string `json:"s3_filepath_prefix"`
 	MetadataFile   string `json:"metadata_file"`
+	Override       bool   `json:"override"`
 }
 
 type OutResponse struct {

--- a/out/release/release_creator.go
+++ b/out/release/release_creator.go
@@ -172,15 +172,23 @@ func (rc ReleaseCreator) Create() (pivnet.Release, error) {
 
 	for _, r := range releases {
 		if r.Version == version {
-			rc.logger.Info(fmt.Sprintf(
-				"Deleting existing release: '%s' - id: '%d'",
-				r.Version,
-				r.ID,
-			))
+			if rc.params.Override {
+				rc.logger.Info(fmt.Sprintf(
+					"Deleting existing release: '%s' - id: '%d'",
+					r.Version,
+					r.ID,
+				))
 
-			err := rc.pivnet.DeleteRelease(rc.productSlug, r)
-			if err != nil {
-				return pivnet.Release{}, err
+				err := rc.pivnet.DeleteRelease(rc.productSlug, r)
+				if err != nil {
+					return pivnet.Release{}, err
+				}
+			} else {
+				return pivnet.Release{}, fmt.Errorf(
+					"Release '%s' with version '%s' already exists.",
+					rc.productSlug,
+					version,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
- previously, the `out` portion of the resource would replace the
artifacts on the Pivotal Network if the release and version matched
- this changes the default behavior to error instead
- also implements a configuration parameter, `override`, which will use
the previous behavior of re-uploading when the release and version are
the same.

[#158845350](https://www.pivotaltracker.com/story/show/158845350)

Signed-off-by: Josh Russett <jrussett@pivotal.io>

Thank you for contributing to the Pivnet Resource!

- Have you made this pull request to the `develop` branch?
- Have you [run the tests locally](https://github.com/pivotal-cf/pivnet-resource#running-the-tests)?
