### PR TITLE
Pivnet-Resource fails properly on SHA/MD5 mismatch

### DIFF
--- a/out/release/release_uploader.go
+++ b/out/release/release_uploader.go
@@ -191,7 +191,7 @@ func (u ReleaseUploader) pollForProductFile(productFile pivnet.ProductFile) erro
 				return err
 			}
 
-			if pf.FileTransferStatus == "complete" {
+			if pf.FileTransferStatus != "in_progress" {
 				u.logger.Info(fmt.Sprintf(
 					"Product file: '%s' async transfer complete",
 					productFile.Name,
@@ -200,7 +200,11 @@ func (u ReleaseUploader) pollForProductFile(productFile pivnet.ProductFile) erro
 				timeoutTimer.Stop()
 				pollTicker.Stop()
 
-				return nil
+				if pf.FileTransferStatus != "complete" {
+					return fmt.Errorf("%s", pf.FileTransferStatus)
+				} else {
+					return nil
+				}
 			}
 
 			u.logger.Info(fmt.Sprintf(


### PR DESCRIPTION
  - Previously, this release_uploader would wait for a
    file_transfer_status to be 'complete', else it would
    time out if it had failed due to SHA/MD5 mismatch.
  - It now checks to see whether a file_transfer_status is
    'in_progress' or not, and fails if it is not 'in_progress'
    but is not 'complete' either.

[#161127408]

Signed-off-by: Paul Nikonowicz <pnikonowicz@pivotal.io>

Thank you for contributing to the Pivnet Resource!

- Have you made this pull request to the `develop` branch?
- Have you [run the tests locally](https://github.com/pivotal-cf/pivnet-resource#running-the-tests)?
