### PR TITLE
Add support for `product_files[].file_version` on put

### DIFF
--- a/metadata/README.md
+++ b/metadata/README.md
@@ -156,6 +156,10 @@ All other keys are optional. The purpose of the keys is as follows:
 * `description` *Optional.* The file description
   (also known as _File Notes_ in Pivotal Network).
 
+* `file_version` *Optional.* The version number which will be displayed next to
+  the filename in Pivotal Network. Defaults to `release.version` if not
+  specified.
+
 * `upload_as` *Optional.* The display name for the file in Pivotal Network.
   This affects only the display name; the filename of the uploaded file remains
   the same as that of the local file.

--- a/out/release/release_uploader.go
+++ b/out/release/release_uploader.go
@@ -25,6 +25,7 @@ type ReleaseUploader struct {
 
 type ProductFileMetadata struct {
 	description        string
+	fileVersion        string
 	docsURL            string
 	systemRequirements []string
 	platforms          []string
@@ -237,11 +238,15 @@ func (u ReleaseUploader) getProductFileConfig(exactGlob string, awsObjectKey str
 		return pivnet.CreateProductFileConfig{}, err
 	}
 
+	fileVersion := release.Version
+	if fileData.fileVersion != "" {
+		fileVersion = fileData.fileVersion
+	}
 	productFileConfig := pivnet.CreateProductFileConfig{
 		ProductSlug:        u.productSlug,
 		Name:               fileData.uploadAs,
 		AWSObjectKey:       awsObjectKey,
-		FileVersion:        release.Version,
+		FileVersion:        fileVersion,
 		SHA256:             fileContentsSHA256,
 		MD5:                fileContentsMD5,
 		Description:        fileData.description,
@@ -281,6 +286,10 @@ func (u ReleaseUploader) getFileData(exactGlob string) ProductFileMetadata {
 
 			if f.FileType != "" {
 				fileData.fileType = f.FileType
+			}
+
+			if f.FileVersion != "" {
+				fileData.fileVersion = f.FileVersion
 			}
 
 			if f.DocsURL != "" {

--- a/out/release/release_uploader_test.go
+++ b/out/release/release_uploader_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/pivotal-cf/go-pivnet"
+	pivnet "github.com/pivotal-cf/go-pivnet"
 	"github.com/pivotal-cf/go-pivnet/logger"
 	"github.com/pivotal-cf/go-pivnet/logshim"
 	"github.com/pivotal-cf/pivnet-resource/metadata"
@@ -33,19 +33,19 @@ var _ = Describe("ReleaseUploader", func() {
 
 		mdata metadata.Metadata
 
-		existingProductFiles []pivnet.ProductFile
-		actualSHA256Sum      string
-		actualMD5Sum         string
-		newAWSObjectKey      string
+		existingProductFiles      []pivnet.ProductFile
+		actualSHA256Sum           string
+		actualMD5Sum              string
+		newAWSObjectKey           string
 		productFileTransferStatus string
 
-		existingProductFilesErr error
-		createProductFileErr    error
-		uploadFileErr           error
-		computeAWSObjectKeyError  error
-		sha256SumFileErr        error
-		md5SumFileErr           error
-		productFileErr          error
+		existingProductFilesErr  error
+		createProductFileErr     error
+		uploadFileErr            error
+		computeAWSObjectKeyError error
+		sha256SumFileErr         error
+		md5SumFileErr            error
+		productFileErr           error
 	)
 
 	BeforeEach(func() {
@@ -204,6 +204,20 @@ var _ = Describe("ReleaseUploader", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("already exists on S3"))
 				})
+			})
+		})
+
+		Context("when `file_version` is specified", func() {
+			BeforeEach(func() {
+				mdata.ProductFiles[0].FileVersion = "some-file-version"
+			})
+
+			It("uploads the product file with the specified version", func() {
+				err := uploader.Upload(pivnetRelease, []string{"some/file"})
+				Expect(err).NotTo(HaveOccurred())
+
+				createArgs := uploadClient.CreateProductFileArgsForCall(0)
+				Expect(createArgs.FileVersion).To(Equal("some-file-version"))
 			})
 		})
 


### PR DESCRIPTION
- This allows us to attach a single file to multiple releases, the file
  can be versioned independently of its parent release

[#157640195] **Explore** update our pipelines to add existing files with the new pivnet resource

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>

SIDE NOTE: It looks like the PR template is asking people to make it off the `develop` branch, which doesn't exist anymore?