### PR TITLE
Update Dockerfile add CA certificates so we can talk to PivNet without x509 errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ ADD cmd/out/out /opt/resource/out
 RUN chmod +x /opt/resource/*
 
 RUN apk add bash
+RUN apk add ca-certificates


### PR DESCRIPTION
add CA certificates so we can actually talk to PivNet without x509 errors
should resolve #109 