### PR TITLE
Make polling for product file async transfers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ for more details on the structure of the metadata file.
   See [metadata](https://github.com/pivotal-cf/pivnet-resource/blob/master/metadata)
   for more details on the structure of the metadata file.
 
+* `skip_product_file_polling`: *Optional.*
+  Boolean. Skip product file validation checks after upload. Pivotal Network still validates the files asynchronously
+  but _waiting_ for the results will not happen as part of the `put:` process. **Note:** All associated product files
+  in a release must still clear validation before the release can be promoted from _Admins Only_ visibility.
+
 * `override`: *Optional.*
   Boolean. Forces re-upload of releases of releases and versions that are
   already present on the Pivotal Network.

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -200,6 +200,7 @@ func main() {
 		input.Source.ProductSlug,
 		asyncTimeout,
 		pollFrequency,
+		input.Params.SkipProductFilePolling,
 	)
 
 	releaseUserGroupsUpdater := release.NewUserGroupsUpdater(

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -57,9 +57,10 @@ type OutRequest struct {
 }
 
 type OutParams struct {
-	FileGlob       string `json:"file_glob"`
-	MetadataFile   string `json:"metadata_file"`
-	Override       bool   `json:"override"`
+	FileGlob               string `json:"file_glob"`
+	MetadataFile           string `json:"metadata_file"`
+	SkipProductFilePolling bool   `json:"skip_product_file_polling"`
+	Override               bool   `json:"override"`
 }
 
 type OutResponse struct {

--- a/out/release/release_uploader.go
+++ b/out/release/release_uploader.go
@@ -21,6 +21,7 @@ type ReleaseUploader struct {
 	productSlug   string
 	asyncTimeout  time.Duration
 	pollFrequency time.Duration
+	skipPolling   bool
 }
 
 type ProductFileMetadata struct {
@@ -71,6 +72,7 @@ func NewReleaseUploader(
 	productSlug string,
 	asyncTimeout time.Duration,
 	pollFrequency time.Duration,
+	skipPolling bool,
 ) ReleaseUploader {
 	return ReleaseUploader{
 		s3:            s3,
@@ -83,6 +85,7 @@ func NewReleaseUploader(
 		productSlug:   productSlug,
 		asyncTimeout:  asyncTimeout,
 		pollFrequency: pollFrequency,
+		skipPolling:   skipPolling,
 	}
 }
 
@@ -173,6 +176,14 @@ func (u ReleaseUploader) Upload(release pivnet.Release, exactGlobs []string) err
 }
 
 func (u ReleaseUploader) pollForProductFile(productFile pivnet.ProductFile) error {
+	if u.skipPolling {
+		u.logger.Info(fmt.Sprintf(
+			"Skipping polling for product file: '%s'",
+			productFile.Name,
+		))
+		return nil
+	}
+
 	u.logger.Info(fmt.Sprintf(
 		"Polling product file: '%s' for async transfer - will wait up to %v",
 		productFile.Name,

--- a/out/release/release_uploader_test.go
+++ b/out/release/release_uploader_test.go
@@ -46,6 +46,8 @@ var _ = Describe("ReleaseUploader", func() {
 		sha256SumFileErr         error
 		md5SumFileErr            error
 		productFileErr           error
+
+		skipPolling bool
 	)
 
 	BeforeEach(func() {
@@ -101,6 +103,8 @@ var _ = Describe("ReleaseUploader", func() {
 		sha256SumFileErr = nil
 		md5SumFileErr = nil
 		productFileErr = nil
+
+		skipPolling = false
 	})
 
 	JustBeforeEach(func() {
@@ -115,6 +119,7 @@ var _ = Describe("ReleaseUploader", func() {
 			productSlug,
 			asyncTimeout,
 			pollFrequency,
+			skipPolling,
 		)
 
 		sha256Summer.SumFileReturns(actualSHA256Sum, sha256SumFileErr)
@@ -335,6 +340,18 @@ var _ = Describe("ReleaseUploader", func() {
 				Expect(err).To(HaveOccurred())
 
 				Expect(err.Error()).To(ContainSubstring("timed out"))
+			})
+		})
+
+		Context("when the skipPolling argument is passed in", func() {
+			BeforeEach(func() {
+				asyncTimeout = pollFrequency / 2
+				skipPolling = true
+			})
+
+			It("ignores ", func() {
+				err := uploader.Upload(pivnetRelease, []string{""})
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION
Some users upload very large files to Pivotal Network and thus having
the resource block on that step can be grieving - especially when the job
errors because of internal timeouts.

Another workflow can be to have the resource upload the release and
product files correctly and then address any product checksum validation
concerns when switching from 'Admins Only' visibility.