### PR TITLE
Call finalizer when updating an existing release

### DIFF
--- a/out/out_command.go
+++ b/out/out_command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pivotal-cf/go-pivnet/v7/logger"
 	"github.com/pivotal-cf/pivnet-resource/v3/concourse"
 	"github.com/pivotal-cf/pivnet-resource/v3/metadata"
-	"github.com/pivotal-cf/pivnet-resource/v3/versions"
 )
 
 type OutCommand struct {
@@ -192,15 +191,6 @@ func (c OutCommand) Run(input concourse.OutRequest) (concourse.OutResponse, erro
 		if err != nil {
 			return concourse.OutResponse{}, err
 		}
-		outputVersion, err := versions.CombineVersionAndFingerprint(pivnetRelease.Version, pivnetRelease.SoftwareFilesUpdatedAt)
-		if err != nil {
-			return concourse.OutResponse{}, err
-		}
-		out = concourse.OutResponse{
-			Version: concourse.Version{
-				ProductVersion: outputVersion,
-			},
-		}
 	}
 
 	if c.skipUpload {
@@ -248,12 +238,10 @@ func (c OutCommand) Run(input concourse.OutRequest) (concourse.OutResponse, erro
 		if err != nil {
 			return concourse.OutResponse{}, err
 		}
-
-		out, err = c.finalizer.Finalize(input.Source.ProductSlug, pivnetRelease.Version)
-		if err != nil {
-			return concourse.OutResponse{}, err
-		}
-
+	}
+	out, err = c.finalizer.Finalize(input.Source.ProductSlug, pivnetRelease.Version)
+	if err != nil {
+		return concourse.OutResponse{}, err
 	}
 
 	c.logger.Info("Put complete")

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -424,7 +424,7 @@ var _ = Describe("Out", func() {
 
 					Expect(response).To(Equal(concourse.OutResponse{
 						Version: concourse.Version{
-							ProductVersion: "existing-product-version#2021-01-01",
+							ProductVersion: "some-new-version",
 						},
 					}))
 
@@ -441,7 +441,7 @@ var _ = Describe("Out", func() {
 					Expect(dependencySpecifiersCreator.CreateDependencySpecifiersCallCount()).To(Equal(0))
 					Expect(releaseUpgradePathsAdder.AddReleaseUpgradePathsCallCount()).To(Equal(0))
 					Expect(upgradePathSpecifiersCreator.CreateUpgradePathSpecifiersCallCount()).To(Equal(0))
-					Expect(finalizer.FinalizeCallCount()).To(Equal(0))
+					Expect(finalizer.FinalizeCallCount()).To(Equal(1))
 				})
 			})
 


### PR DESCRIPTION
- This will get the proper fingerprint and release information for the
output of the put step
